### PR TITLE
[Feat] 채팅방 리스트 API - 컨트롤러 - 조회 작성

### DIFF
--- a/moyoserver/src/main/java/com/timmyroom/moyoserver/chatroomList/controller/ChatroomListController.java
+++ b/moyoserver/src/main/java/com/timmyroom/moyoserver/chatroomList/controller/ChatroomListController.java
@@ -1,0 +1,28 @@
+package com.timmyroom.moyoserver.chatroomList.controller;
+
+import com.timmyroom.moyoserver.chatroomList.dto.ChatroomInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+public class ChatroomListController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ChatroomListController.class);
+
+    @ResponseStatus(HttpStatus.OK)
+    @RequestMapping(value = "/chatRoomList", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<ChatroomInfo> chatRoomList() {
+        // TO-DO : 서비스 메소드 호출하여 채팅방 리스트 가져오기 (Controller<->Service<->Repository<->DB)
+        List<ChatroomInfo> chatroomInfoList = new ArrayList<ChatroomInfo>();
+        chatroomInfoList.add(new ChatroomInfo("채팅방1",true,4,"추감기"));
+        chatroomInfoList.add(new ChatroomInfo("채팅방2",true,4,"파스칼"));
+
+        return chatroomInfoList;
+    }
+}

--- a/moyoserver/src/main/java/com/timmyroom/moyoserver/chatroomList/dto/ChatroomInfo.java
+++ b/moyoserver/src/main/java/com/timmyroom/moyoserver/chatroomList/dto/ChatroomInfo.java
@@ -1,0 +1,20 @@
+package com.timmyroom.moyoserver.chatroomList.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatroomInfo {
+    private String name;
+    private boolean isActivated;
+    private int participant;
+    private String hostName;
+
+    public ChatroomInfo(String name, boolean isActivated, int participant, String hostName) {
+        this.name = name;
+        this.isActivated = isActivated;
+        this.participant = participant;
+        this.hostName = hostName;
+    }
+}


### PR DESCRIPTION
<개요>
- 채팅방 리스트를 조회하는 API의 컨트롤러 부분 작성함

<테스트 방법>
- http://localhost:8080/chatRoomList 과 같은 URI로 요청하면 채팅방 리스트 더미 데이터를 수신할 수 있음